### PR TITLE
Support for type declarations 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,83 @@
+import rollup from 'rollup'
+
+interface Options {
+
+  /**
+   * Define the base dir to watch from.
+   *
+   * @default process.cwd()
+   */
+  readonly dir?: string
+
+  /**
+   * Whether or not to remove all files within `dist` when rollup starts up.
+   *
+   * @default true
+   */
+  readonly clean?: string
+
+  /**
+   * A function that allows for programatically changing the
+   * destination of files.
+   *
+   * @default false
+   */
+  readonly transform?: (file: string) => string;
+
+   /**
+   * A string defining a package name for the manifest of files to be
+   * copied/watched that you can import in your code.
+   *
+   * @default false
+   */
+  readonly manifest?: string |  boolean
+
+  /**
+   * A shorthand to enable verbose logging. Overrides `loglevel` option if set
+   *
+   * @default false
+   */
+  readonly verbose?: string | boolean
+
+  /**
+   * Specify the exact level to log at
+   *
+   * @default 'info'
+   */
+  readonly loglevel?: 'silly' | 'verbose' | 'info' | 'silent'
+}
+
+interface GlobSyncOptions {
+
+  /**
+   * Array of glob patterns to use for finding files to copy.
+   */
+  readonly globs?:  string | ReadonlyArray<string>
+
+  /**
+   * Array of glob patterns to use for finding files to copy.
+   *
+   * @deprecated use `globs`
+   */
+  readonly patterns?:  string | ReadonlyArray<string>
+
+  /**
+   * Directory to copy files into.
+   *
+   * @default './dist'
+   */
+  readonly dest: string
+
+  /**
+   * The open/closr delimeters
+   */
+  readonly options?: Options
+
+}
+
+/**
+ * Rollup plugin to take a list of globs, copy them on the first build,
+ * and optionally watch for changes and sync those over afterwards.
+ */
+export default function globsync(options?: GlobSyncOptions): rollup.Plugin;
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,25 @@
 import rollup from 'rollup'
 
-interface Options {
+interface GlobSyncOptions {
+
+  /**
+   * Array of glob patterns to use for finding files to copy.
+   */
+  readonly globs:  string | ReadonlyArray<string>
+
+  /**
+   * Array of glob patterns to use for finding files to copy.
+   *
+   * @deprecated use `globs`
+   */
+  readonly patterns?:  string | ReadonlyArray<string>
+
+  /**
+   * Directory to copy files into.
+   *
+   * @default './dist'
+   */
+  readonly dest: string
 
   /**
    * Define the base dir to watch from.
@@ -24,6 +43,7 @@ interface Options {
    */
   readonly transform?: (file: string) => string;
 
+
    /**
    * A string defining a package name for the manifest of files to be
    * copied/watched that you can import in your code.
@@ -45,33 +65,6 @@ interface Options {
    * @default 'info'
    */
   readonly loglevel?: 'silly' | 'verbose' | 'info' | 'silent'
-}
-
-interface GlobSyncOptions {
-
-  /**
-   * Array of glob patterns to use for finding files to copy.
-   */
-  readonly globs?:  string | ReadonlyArray<string>
-
-  /**
-   * Array of glob patterns to use for finding files to copy.
-   *
-   * @deprecated use `globs`
-   */
-  readonly patterns?:  string | ReadonlyArray<string>
-
-  /**
-   * Directory to copy files into.
-   *
-   * @default './dist'
-   */
-  readonly dest: string
-
-  /**
-   * The open/closr delimeters
-   */
-  readonly options?: Options
 
 }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Rollup plugin to copy globs & watch for changes",
   "author": "Pat Cavit <npm@patcavit.com>",
   "main": "index.js",
+  "types": "index.d.ts",
   "version": "2.1.0",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Provides type declarations – I noticed that option value `globs` was set in tests but docs and current version uses `patterns` when defining paths, I've included both for now. 
